### PR TITLE
削除済みの練習会の参加情報が残ってしまい、getMyJoinedPracticesAPI実行時にエラーが発生してしまう事象を解決。

### DIFF
--- a/spring-boot/src/main/resources/db/migration/V1.0.5__create_participations_table.sql
+++ b/spring-boot/src/main/resources/db/migration/V1.0.5__create_participations_table.sql
@@ -1,5 +1,7 @@
 CREATE TABLE participations (
     practice_id         binary(16),
     user_firebase_uid   varchar(100),
-    PRIMARY KEY (practice_id, user_firebase_uid)
+    PRIMARY KEY (practice_id, user_firebase_uid),
+    FOREIGN KEY (practice_id) REFERENCES practices(uuid) ON UPDATE CASCADE ON DELETE CASCADE,
+    FOREIGN KEY (user_firebase_uid) REFERENCES users(firebase_uid) ON UPDATE CASCADE ON DELETE CASCADE
 );


### PR DESCRIPTION
解決方法：participationsテーブルのカラムに、外部キー制約を設定し、カスケードに削除されるように修正